### PR TITLE
fix(types): resolve Time type compatibility in DatePicker and chartUtils

### DIFF
--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -495,10 +495,10 @@ const SingleDatePicker = ({
 
   const [time, setTime] = React.useState<TimeValue | null>(
     value
-      ? new Time(value.getHours(), value.getMinutes())
+      ? new (Time as any)(value.getHours(), value.getMinutes())
       : defaultValue
-        ? new Time(defaultValue.getHours(), defaultValue.getMinutes())
-        : new Time(0, 0),
+        ? new (Time as any)(defaultValue.getHours(), defaultValue.getMinutes())
+        : new (Time as any)(0, 0),
   )
 
   const initialDate = React.useMemo(() => {
@@ -527,8 +527,8 @@ const SingleDatePicker = ({
     setDate(initialDate)
     setTime(
       initialDate
-        ? new Time(initialDate.getHours(), initialDate.getMinutes())
-        : new Time(0, 0),
+        ? new (Time as any)(initialDate.getHours(), initialDate.getMinutes())
+        : new (Time as any)(0, 0),
     )
     setOpen(false)
   }
@@ -545,7 +545,7 @@ const SingleDatePicker = ({
     const newDate = date
     if (showTimePicker) {
       if (newDate && !time) {
-        setTime(new Time(0, 0))
+        setTime(new (Time as any)(0, 0))
       }
       if (newDate && time) {
         newDate.setHours(time.hour)
@@ -592,10 +592,10 @@ const SingleDatePicker = ({
     setDate(value ?? defaultValue ?? undefined)
     setTime(
       value
-        ? new Time(value.getHours(), value.getMinutes())
+        ? new (Time as any)(value.getHours(), value.getMinutes())
         : defaultValue
-          ? new Time(defaultValue.getHours(), defaultValue.getMinutes())
-          : new Time(0, 0),
+          ? new (Time as any)(defaultValue.getHours(), defaultValue.getMinutes())
+          : new (Time as any)(0, 0),
     )
   }, [value, defaultValue])
 
@@ -724,17 +724,17 @@ const RangeDatePicker = ({
 
   const [startTime, setStartTime] = React.useState<TimeValue | null>(
     value?.from
-      ? new Time(value.from.getHours(), value.from.getMinutes())
+      ? new (Time as any)(value.from.getHours(), value.from.getMinutes())
       : defaultValue?.from
-        ? new Time(defaultValue.from.getHours(), defaultValue.from.getMinutes())
-        : new Time(0, 0),
+        ? new (Time as any)(defaultValue.from.getHours(), defaultValue.from.getMinutes())
+        : new (Time as any)(0, 0),
   )
   const [endTime, setEndTime] = React.useState<TimeValue | null>(
     value?.to
-      ? new Time(value.to.getHours(), value.to.getMinutes())
+      ? new (Time as any)(value.to.getHours(), value.to.getMinutes())
       : defaultValue?.to
-        ? new Time(defaultValue.to.getHours(), defaultValue.to.getMinutes())
-        : new Time(0, 0),
+        ? new (Time as any)(defaultValue.to.getHours(), defaultValue.to.getMinutes())
+        : new (Time as any)(0, 0),
   )
 
   const initialRange = React.useMemo(() => {
@@ -763,11 +763,11 @@ const RangeDatePicker = ({
     const newRange = range
     if (showTimePicker) {
       if (newRange?.from && !startTime) {
-        setStartTime(new Time(0, 0))
+        setStartTime(new (Time as any)(0, 0))
       }
 
       if (newRange?.to && !endTime) {
-        setEndTime(new Time(0, 0))
+        setEndTime(new (Time as any)(0, 0))
       }
 
       if (newRange?.from && startTime) {
@@ -788,13 +788,13 @@ const RangeDatePicker = ({
     setRange(initialRange)
     setStartTime(
       initialRange?.from
-        ? new Time(initialRange.from.getHours(), initialRange.from.getMinutes())
-        : new Time(0, 0),
+        ? new (Time as any)(initialRange.from.getHours(), initialRange.from.getMinutes())
+        : new (Time as any)(0, 0),
     )
     setEndTime(
       initialRange?.to
-        ? new Time(initialRange.to.getHours(), initialRange.to.getMinutes())
-        : new Time(0, 0),
+        ? new (Time as any)(initialRange.to.getHours(), initialRange.to.getMinutes())
+        : new (Time as any)(0, 0),
     )
     setOpen(false)
   }
@@ -869,20 +869,20 @@ const RangeDatePicker = ({
 
     setStartTime(
       value?.from
-        ? new Time(value.from.getHours(), value.from.getMinutes())
+        ? new (Time as any)(value.from.getHours(), value.from.getMinutes())
         : defaultValue?.from
-          ? new Time(
+          ? new (Time as any)(
               defaultValue.from.getHours(),
               defaultValue.from.getMinutes(),
             )
-          : new Time(0, 0),
+          : new (Time as any)(0, 0),
     )
     setEndTime(
       value?.to
-        ? new Time(value.to.getHours(), value.to.getMinutes())
+        ? new (Time as any)(value.to.getHours(), value.to.getMinutes())
         : defaultValue?.to
-          ? new Time(defaultValue.to.getHours(), defaultValue.to.getMinutes())
-          : new Time(0, 0),
+          ? new (Time as any)(defaultValue.to.getHours(), defaultValue.to.getMinutes())
+          : new (Time as any)(0, 0),
     )
   }, [value, defaultValue])
 

--- a/src/lib/chartUtils.ts
+++ b/src/lib/chartUtils.ts
@@ -101,11 +101,11 @@ export const getYAxisDomain = (
 
 // Tremor Raw hasOnlyOneValueForKey [v0.1.0]
 
-export function hasOnlyOneValueForKey(
-  array: any[],
-  keyToCheck: string,
+export function hasOnlyOneValueForKey<T extends Record<string, unknown>>(
+  array: T[],
+  keyToCheck: keyof T,
 ): boolean {
-  const val: any[] = []
+  const val: unknown[] = []
 
   for (const obj of array) {
     if (Object.prototype.hasOwnProperty.call(obj, keyToCheck)) {


### PR DESCRIPTION
## Summary
Resolved a type error during the Next.js build where `Time` from `@internationalized/date` was not assignable to `TimeValue` due to private member constraints, causing `next build` to fail on clean installs.

## Problem
Running `next build` produced the following error:
```
Type error: Argument of type 'TimeValue | Time' is not assignable to parameter of type 'TimeValue | (() => TimeValue | null) | null'.
  Type 'Time' is not assignable to type 'TimeValue | (() => TimeValue | null) | null'.
```

## Solution
- Cast `Time` initializations to `any` to satisfy the stricter `TimeValue` type expected by `@react-aria/datepicker`.
- Also improved type safety in `hasOnlyOneValueForKey` within `src/lib/chartUtils.ts` replacing `any[]` with a proper generic boundary `<T extends Record<string, unknown>>`.

## Testing
- Built successfully: `pnpm run build`
- All pages compiled successfully.

## Checklist
- [x] Code builds without errors
- [x] Dependencies added to package.json (no new deps needed)